### PR TITLE
Allow user defined function to be used for reconnection pausing

### DIFF
--- a/redisconn/conn_test.go
+++ b/redisconn/conn_test.go
@@ -226,10 +226,10 @@ func (s *Suite) TestSendMany_FailedWholeBatchBecauseOfOne() {
 	}
 }
 
-func (s *Suite) TestStopped_DoesntConnectWithNegativeReconnectPause() {
+func (s *Suite) TestStopped_DoesntConnectWithNoReconnect() {
 	s.s.Stop()
 	opts := defopts
-	opts.ReconnectPause = -1
+	opts.ReconnectThrottle = NoReconnect{}
 	_, err := Connect(s.ctx, s.s.Addr(), opts)
 	s.r().NotNil(err)
 	rerr := s.AsError(err)

--- a/redisconn/reconnect.go
+++ b/redisconn/reconnect.go
@@ -1,0 +1,122 @@
+package redisconn
+
+import (
+	"sync"
+	"time"
+)
+
+type ReconnectThrottle interface {
+	GetBackoff(conn *Connection, now time.Time) time.Duration
+	ConnClosed(conn *Connection)
+}
+
+type NoReconnect struct{}
+
+func (n NoReconnect) GetBackoff(_ *Connection, _ time.Time) time.Duration {
+	panic("not implemented")
+}
+
+func (n NoReconnect) ConnClosed(_ *Connection) {
+	panic("not implemented")
+}
+
+type DurationReconnect struct {
+	dur time.Duration
+}
+
+func NewDurationReconnect(dur time.Duration) ReconnectThrottle {
+	return &DurationReconnect{
+		dur: dur,
+	}
+}
+
+func (d *DurationReconnect) GetBackoff(_ *Connection, _ time.Time) time.Duration {
+	return d.dur
+}
+
+func (d *DurationReconnect) ConnClosed(_ *Connection) {}
+
+// ExpBackoffReconnect implements an exponential backoff with a decorrelated jitter
+type ExpBackoffReconnect struct {
+	randIntFunc func(max int64) int64
+	base        time.Duration // minimum time to sleep
+	cap         time.Duration // maximum time to sleep
+	reset       time.Duration // after how much time to go back tofi base
+	mu          sync.Mutex
+	trackers    map[*Connection]*timeTracker
+}
+
+type timeTracker struct {
+	cap        time.Duration // based off of ExpBackoffReconnect.cap but includes jitter
+	backoff    time.Duration
+	updateTime time.Time // used to reset the backoff after ExpBackoffReconnect.reset window
+}
+
+func NewExpBackoffReconnect(randIntFunc func(max int64) int64, base time.Duration, cap time.Duration, reset time.Duration) ReconnectThrottle {
+	return &ExpBackoffReconnect{
+		randIntFunc: randIntFunc,
+		base:        base,
+		cap:         cap,
+		reset:       reset,
+		mu:          sync.Mutex{},
+		trackers:    map[*Connection]*timeTracker{},
+	}
+}
+
+// getNewCap provides a new cap with an element of jitter. The value will be within 1/8 of cap.
+func (e *ExpBackoffReconnect) getNewCap() time.Duration {
+	window := e.cap / 8
+
+	jitter := e.randIntFunc(window.Nanoseconds())
+	return e.cap - (time.Duration(jitter) * time.Nanosecond)
+}
+
+func (e *ExpBackoffReconnect) GetBackoff(conn *Connection, now time.Time) time.Duration {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	var tracker = e.trackers[conn]
+	if tracker == nil {
+		tracker = &timeTracker{
+			backoff: e.base,
+			cap:     e.getNewCap(),
+		}
+
+		e.trackers[conn] = tracker
+	} else {
+		// Reset the sleep time back to base if enough time has passed
+		if tracker.updateTime.Add(e.reset).Before(now) {
+			tracker.backoff = e.base
+		}
+	}
+
+	tracker.updateTime = now
+
+	// Pick new backoff
+	maxBackoff := 3 * tracker.backoff
+
+	// Get jitter between the base and new backoff
+	newBackoff := maxBackoff - e.base
+	if newBackoff > 0 {
+		// Add jitter to backoff
+		val := e.randIntFunc(newBackoff.Nanoseconds()) + e.base.Nanoseconds()
+		newBackoff = time.Duration(val) * time.Nanosecond
+	} else {
+		newBackoff = e.base
+	}
+
+	// Clamp the backoff
+	if newBackoff > tracker.cap {
+		newBackoff = tracker.cap
+	}
+
+	tracker.backoff = newBackoff
+
+	return tracker.backoff
+}
+
+func (e *ExpBackoffReconnect) ConnClosed(conn *Connection) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	delete(e.trackers, conn)
+}

--- a/redisconn/reconnect.go
+++ b/redisconn/reconnect.go
@@ -78,8 +78,9 @@ func (e *ExpBackoffReconnect) GetBackoff(conn *Connection, now time.Time) time.D
 	var tracker = e.trackers[conn]
 	if tracker == nil {
 		tracker = &timeTracker{
-			backoff: e.base,
-			cap:     e.getNewCap(),
+			backoff:    e.base,
+			cap:        e.getNewCap(),
+			updateTime: now,
 		}
 
 		e.trackers[conn] = tracker
@@ -87,10 +88,9 @@ func (e *ExpBackoffReconnect) GetBackoff(conn *Connection, now time.Time) time.D
 		// Reset the sleep time back to base if enough time has passed
 		if tracker.updateTime.Add(e.reset).Before(now) {
 			tracker.backoff = e.base
+			tracker.updateTime = now
 		}
 	}
-
-	tracker.updateTime = now
 
 	// Pick new backoff
 	maxBackoff := 3 * tracker.backoff

--- a/redisconn/reconnect_test.go
+++ b/redisconn/reconnect_test.go
@@ -1,0 +1,97 @@
+package redisconn
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestDurationReconnect(t *testing.T) {
+	dur := time.Duration(42) * time.Millisecond
+	r := NewDurationReconnect(dur)
+
+	assert.Equal(t, dur, r.GetBackoff(nil, time.Now()))
+}
+
+func TestExpBackoffReconnectStepsMax(t *testing.T) {
+	base := time.Duration(1) * time.Millisecond
+	max := time.Duration(200) * time.Millisecond
+	reset := 5 * time.Minute
+
+	randIntFunc := func(max int64) int64 { return max }
+
+	r := NewExpBackoffReconnect(randIntFunc, base, max, reset)
+	c := &Connection{}
+	now, _ := time.Parse(time.ANSIC, "Mon Jan 2 15:04:05 2022")
+
+	assert.Equal(t, 3*time.Millisecond, r.GetBackoff(c, now))
+	assert.Equal(t, 9*time.Millisecond, r.GetBackoff(c, now))
+	assert.Equal(t, 27*time.Millisecond, r.GetBackoff(c, now))
+	assert.Equal(t, 81*time.Millisecond, r.GetBackoff(c, now))
+	assert.Equal(t, 175*time.Millisecond, r.GetBackoff(c, now)) // Max
+	assert.Equal(t, 175*time.Millisecond, r.GetBackoff(c, now)) // Max
+
+	later, _ := time.Parse(time.ANSIC, "Mon Jan 2 15:09:15 2022")
+	assert.Equal(t, 3*time.Millisecond, r.GetBackoff(c, later))
+}
+
+func TestExpBackoffReconnectStepsMin(t *testing.T) {
+	base := time.Duration(1) * time.Millisecond
+	max := time.Duration(200) * time.Millisecond
+	reset := 5 * time.Minute
+
+	randIntFunc := func(max int64) int64 { return 0 }
+
+	r := NewExpBackoffReconnect(randIntFunc, base, max, reset)
+	c := &Connection{}
+	now, _ := time.Parse(time.ANSIC, "Mon Jan 2 15:04:05 2022")
+
+	assert.Equal(t, 1*time.Millisecond, r.GetBackoff(c, now))
+	assert.Equal(t, 1*time.Millisecond, r.GetBackoff(c, now))
+	assert.Equal(t, 1*time.Millisecond, r.GetBackoff(c, now))
+
+	later, _ := time.Parse(time.ANSIC, "Mon Jan 2 15:09:15 2022")
+	assert.Equal(t, 1*time.Millisecond, r.GetBackoff(c, later))
+}
+
+func TestExpBackoffReconnectMultipleConns(t *testing.T) {
+	base := time.Duration(1) * time.Millisecond
+	max := time.Duration(200) * time.Millisecond
+	reset := 5 * time.Minute
+
+	randIntFunc := func(max int64) int64 { return max }
+
+	r := NewExpBackoffReconnect(randIntFunc, base, max, reset)
+	c1 := &Connection{}
+	c2 := &Connection{}
+
+	now, _ := time.Parse(time.ANSIC, "Mon Jan 2 15:04:05 2022")
+
+	assert.Equal(t, 3*time.Millisecond, r.GetBackoff(c1, now))
+	assert.Equal(t, 3*time.Millisecond, r.GetBackoff(c2, now))
+
+	assert.Equal(t, 9*time.Millisecond, r.GetBackoff(c1, now))
+	assert.Equal(t, 9*time.Millisecond, r.GetBackoff(c2, now))
+
+	assert.Equal(t, 27*time.Millisecond, r.GetBackoff(c1, now))
+	assert.Equal(t, 27*time.Millisecond, r.GetBackoff(c2, now))
+}
+
+func TestExpBackoffReconnectConnClosed(t *testing.T) {
+	base := time.Duration(1) * time.Millisecond
+	max := time.Duration(200) * time.Millisecond
+	reset := 5 * time.Minute
+
+	randIntFunc := func(max int64) int64 { return max }
+
+	r := NewExpBackoffReconnect(randIntFunc, base, max, reset)
+	c := &Connection{}
+
+	now, _ := time.Parse(time.ANSIC, "Mon Jan 2 15:04:05 2022")
+
+	assert.Equal(t, 3*time.Millisecond, r.GetBackoff(c, now))
+	assert.Equal(t, 9*time.Millisecond, r.GetBackoff(c, now))
+	r.ConnClosed(c)
+
+	assert.Equal(t, 3*time.Millisecond, r.GetBackoff(c, now))
+}


### PR DESCRIPTION
This adds the ability for users to define their own function to determine pausing after a connection failure. The provided implementation is no reconnect, static reconnect, and exponential backoff with decorrelated jitter.