### PR TITLE
Test against redis 6.2 and fix integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-REDIS_ARCHIVE ?= https://github.com/joomcode/redis/archive
-REDIS_VERSION ?= debian-5.0.7-fixes
+REDIS_ARCHIVE ?= https://github.com/redis/redis/archive
+REDIS_VERSION ?= 6.2.6
 
 test: testcluster testconn testredis
 

--- a/testbed/cluster.go
+++ b/testbed/cluster.go
@@ -77,10 +77,10 @@ func (cl *Cluster) Start() {
 // WaitClusterOk wait for cluster configuration to be stable.
 func (cl *Cluster) WaitClusterOk() {
 	i := 0
-	t := time.AfterFunc(20*time.Second, func() { panic("cluster didn't stabilize") })
+	t := time.AfterFunc(10*time.Second, func() { panic("cluster didn't stabilize") })
 	defer t.Stop()
 	for !cl.ClusterOk() {
-		if i++; i == 20 {
+		if i++; i == 10 {
 			cl.AttemptFailover()
 		}
 		time.Sleep(100 * time.Millisecond)

--- a/testbed/cluster.go
+++ b/testbed/cluster.go
@@ -34,6 +34,7 @@ func NewCluster(startport uint16) *Cluster {
 			"--cluster-slave-validity-factor", "1000",
 			"--slave-serve-stale-data", "yes",
 			"--cluster-require-full-coverage", "no",
+			"--cluster-allow-replica-migration", "no",
 		}
 		cl.Node[i].Start()
 		cl.Node[i].SetupNodeId()
@@ -212,6 +213,7 @@ func (cl *Cluster) StartSeventhNode() {
 		"--cluster-slave-validity-factor", "1000",
 		"--slave-serve-stale-data", "yes",
 		"--cluster-require-full-coverage", "no",
+		"--cluster-allow-replica-migration", "no",
 	}
 	cl.Node[6].Start()
 	cl.Node[6].SetupNodeId()


### PR DESCRIPTION
At some point Redis introduced functionality that allowed orphaned replicas or primaries with no slots to become replicas of other primaries. However, this functionality doesn't work for the tests because what from what I understand we want to create a situation where there are 4 primaries and 3 replicas. And slots move from node 0 to node 6. This obviously can't happen if node 6 has become a replica automatically.