### PR TITLE
Allow appending and encoding raw data right on to the redis.Request object

### DIFF
--- a/redis/request_test.go
+++ b/redis/request_test.go
@@ -8,34 +8,43 @@ import (
 )
 
 func TestRequestKey(t *testing.T) {
-	var k string
+	var r Request
+	var k []byte
 	var ok bool
 
-	k, ok = Req("GET", 1).Key()
-	assert.Equal(t, "1", k)
+	r = Req("GET", 1)
+	k, ok = r.KeyByte()
+	assert.Equal(t, "1", string(k))
 	assert.True(t, ok)
 
-	_, ok = Req("GET").Key()
+	r = Req("GET")
+	k, ok = r.KeyByte()
 	assert.False(t, ok)
 
-	k, ok = Req("SET", 1, 2).Key()
-	assert.Equal(t, "1", k)
+	r = Req("SET", 1, 2)
+	k, ok = r.KeyByte()
+	assert.Equal(t, "1", string(k))
 	assert.True(t, ok)
 
-	k, ok = Req("RANDOMKEY").Key()
-	assert.Equal(t, "RANDOMKEY", k)
+	r = Req("RANDOMKEY")
+	k, ok = r.KeyByte()
+
+	assert.Equal(t, "RANDOMKEY", string(k))
 	assert.False(t, ok)
 
-	k, ok = Req("EVAL", "return KEY[1]", 1, 2, 3).Key()
-	assert.Equal(t, "2", k)
+	r = Req("EVAL", "return KEY[1]", 1, 2, 3)
+	k, ok = r.KeyByte()
+	assert.Equal(t, "2", string(k))
 	assert.True(t, ok)
 
-	k, ok = Req("EVALSHA", "1234abcdef", 1, 2, 3).Key()
-	assert.Equal(t, "2", k)
+	r = Req("EVALSHA", "1234abcdef", 1, 2, 3)
+	k, ok = r.KeyByte()
+	assert.Equal(t, "2", string(k))
 	assert.True(t, ok)
 
-	k, ok = Req("BITOP", "AND", 1, 2).Key()
-	assert.Equal(t, "1", k)
+	r = Req("BITOP", "AND", 1, 2)
+	k, ok = r.KeyByte()
+	assert.Equal(t, "1", string(k))
 	assert.True(t, ok)
 }
 

--- a/redis/sender.go
+++ b/redis/sender.go
@@ -79,7 +79,7 @@ func (s ScanOpts) Request(it []byte) Request {
 	if s.Count > 0 {
 		args = append(args, "COUNT", s.Count)
 	}
-	return Request{s.Cmd, args}
+	return Request{s.Cmd, args, nil, 0, nil}
 }
 
 // ScannerBase is internal "parent" object for scanner implementations

--- a/redis/sync.go
+++ b/redis/sync.go
@@ -14,7 +14,7 @@ type Sync struct {
 // Do is convenient method to construct and send request.
 // Returns value that could be either result or error.
 func (s Sync) Do(cmd string, args ...interface{}) interface{} {
-	return s.Send(Request{cmd, args})
+	return s.Send(Request{cmd, args, nil, 0, nil})
 }
 
 // Send sends request to redis.

--- a/redis/sync_context.go
+++ b/redis/sync_context.go
@@ -19,7 +19,7 @@ type SyncCtx struct {
 // Returns value that could be either result or error.
 // When context is cancelled, Do returns ErrRequestCancelled error.
 func (s SyncCtx) Do(ctx context.Context, cmd string, args ...interface{}) interface{} {
-	return s.Send(ctx, Request{cmd, args})
+	return s.Send(ctx, Request{cmd, args, nil, 0, nil})
 }
 
 // Send sends request to redis.

--- a/rediscluster/redisclusterutil/crc16.go
+++ b/rediscluster/redisclusterutil/crc16.go
@@ -3,6 +3,7 @@ package redisclusterutil
 // copied from github.com/mediocregopher/radix.v2/cluster/crc16.go
 
 import (
+	"bytes"
 	"strings"
 )
 
@@ -64,4 +65,16 @@ func Slot(key string) uint16 {
 		}
 	}
 	return CRC16([]byte(key)) % NumSlots
+}
+
+var lBrace = []byte("{")
+var rBrace = []byte("}")
+
+func ByteSlot(key []byte) uint16 {
+	if start := bytes.Index(key, lBrace); start >= 0 {
+		if end := bytes.Index(key[start+1:], rBrace); end > 0 {
+			key = key[start+1 : start+1+end]
+		}
+	}
+	return CRC16(key) % NumSlots
 }

--- a/rediscluster/redisclusterutil/slots.go
+++ b/rediscluster/redisclusterutil/slots.go
@@ -1,18 +1,22 @@
 package redisclusterutil
 
 import (
+	"bytes"
 	"math/rand"
 
 	"github.com/joomcode/redispipe/redis"
 )
 
+var rKey = []byte("RANDOMKEY")
+var eKey = []byte("")
+
 // ReqSlot returns slot number targeted by this command.
 func ReqSlot(req redis.Request) (uint16, bool) {
-	key, ok := req.Key()
-	if key == "RANDOMKEY" && !ok {
+	key, ok := req.KeyByte()
+	if bytes.Equal(rKey, key) && !ok {
 		return uint16(rand.Intn(NumSlots)), true
 	}
-	return Slot(key), ok
+	return ByteSlot(key), ok
 }
 
 // BatchSlot returns slot common for all requests in batch (if there is such common slot).
@@ -35,21 +39,21 @@ func BatchSlot(reqs []redis.Request) (uint16, bool) {
 }
 
 // BatchKey returns first key from a batch that is targeted to common slot.
-func BatchKey(reqs []redis.Request) (string, bool) {
-	var key string
+func BatchKey(reqs []redis.Request) ([]byte, bool) {
+	var key []byte
 	var slot uint16
 	var set bool
 	for _, req := range reqs {
-		k, ok := req.Key()
+		k, ok := req.KeyByte()
 		if !ok {
 			continue
 		}
-		s := Slot(k)
+		s := ByteSlot(k)
 		if !set {
 			key, slot = k, s
 			set = true
 		} else if slot != s {
-			return "", false
+			return eKey, false
 		}
 	}
 	return key, set

--- a/rediscluster/slotrange.go
+++ b/rediscluster/slotrange.go
@@ -224,9 +224,9 @@ func (cfg *clusterConfig) setConnRoles() {
 			}
 			for _, conn := range node.conns {
 				if i == 0 {
-					conn.Send(Request{"READWRITE", nil}, nil, 0)
+					conn.Send(Request{"READWRITE", nil, nil, 0, nil}, nil, 0)
 				} else {
-					conn.SendBatch([]Request{{"READONLY", nil}, {"INFO", nil}},
+					conn.SendBatch([]Request{{"READONLY", nil, nil, 0, nil}, {"INFO", nil, nil, 0, nil}},
 						redis.FuncFuture(sh.setReplicaInfo), uint64(i*2))
 				}
 			}

--- a/redisconn/conn.go
+++ b/redisconn/conn.go
@@ -373,7 +373,7 @@ func (conn *Connection) doSend(req Request, cb Future, n uint64, asking bool) *e
 	futures := conn.futures
 	if asking {
 		// send ASKING request before actual
-		futures = append(futures, future{&dumb, 0, 0, Request{"ASKING", nil}})
+		futures = append(futures, future{&dumb, 0, 0, Request{"ASKING", nil, nil, 0, nil}})
 	}
 	futures = append(futures, future{cb, n, nownano(), req})
 
@@ -485,11 +485,11 @@ func (conn *Connection) doSendBatch(requests []Request, cb Future, start uint64,
 	futures := conn.futures
 	if flags&DoAsking != 0 {
 		// send ASKING request before actual
-		futures = append(futures, future{&dumb, 0, 0, Request{"ASKING", nil}})
+		futures = append(futures, future{&dumb, 0, 0, Request{"ASKING", nil, nil, 0, nil}})
 	}
 	if flags&DoTransaction != 0 {
 		// send MULTI request for transaction start
-		futures = append(futures, future{&dumb, 0, 0, Request{"MULTI", nil}})
+		futures = append(futures, future{&dumb, 0, 0, Request{"MULTI", nil, nil, 0, nil}})
 	}
 
 	now := nownano()
@@ -500,7 +500,7 @@ func (conn *Connection) doSendBatch(requests []Request, cb Future, start uint64,
 
 	if flags&DoTransaction != 0 {
 		// send EXEC request for transaction end
-		futures = append(futures, future{cb, start + uint64(len(requests)), now, Request{"EXEC", nil}})
+		futures = append(futures, future{cb, start + uint64(len(requests)), now, Request{"EXEC", nil, nil, 0, nil}})
 	}
 
 	// should notify writer about this shard having queries

--- a/redisdumb/conn.go
+++ b/redisdumb/conn.go
@@ -59,7 +59,7 @@ func (c *Conn) Do(cmd string, args ...interface{}) interface{} {
 			c.Do("ASKING")
 		}
 		c.C.SetDeadline(time.Now().Add(timeout))
-		req, err = redis.AppendRequest(nil, redis.Request{cmd, args})
+		req, err = redis.AppendRequest(nil, redis.Request{cmd, args, nil, 0, nil})
 		if err == nil {
 			if _, err = c.C.Write(req); err == nil {
 				res := redis.ReadResponse(c.R)
@@ -194,7 +194,7 @@ func Do(addr string, cmd string, args ...interface{}) interface{} {
 	}
 	defer conn.Close()
 	conn.SetDeadline(time.Now().Add(DefaultTimeout))
-	req, rerr := redis.AppendRequest(nil, redis.Request{cmd, args})
+	req, rerr := redis.AppendRequest(nil, redis.Request{cmd, args, nil, 0, nil})
 	if rerr != nil {
 		return rerr
 	}


### PR DESCRIPTION
Assist in improving memory efficiency by allowing clients to use a pre-allocated buffer with `redis.Request` objects