### PR TITLE
Response byte reuse

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ test: testcluster testconn testredis
 	mv redis-$(REDIS_VERSION)/src/redis-server /tmp/redis-server
 	rm redis-$(REDIS_VERSION) -rf
 
-testredis: /tmp/redis-server/redis-server
+testredis:
 	PATH=/tmp/redis-server/:${PATH} go test ./redis
 
 testconn: /tmp/redis-server/redis-server

--- a/redis/byteslice/byteslice.go
+++ b/redis/byteslice/byteslice.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2021 The Gnet Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package byteslice
+
+import (
+	"math"
+	"math/bits"
+	"reflect"
+	"runtime"
+	"sync"
+	"unsafe"
+)
+
+var builtinPool Pool
+
+// Pool consists of 32 sync.Pool, representing byte slices of length from 0 to 32 in powers of 2.
+type Pool struct {
+	pools [32]sync.Pool
+}
+
+// Get returns a byte slice with given length from the built-in pool.
+func Get(size int) []byte {
+	return builtinPool.Get(size)
+}
+
+// Put returns the byte slice to the built-in pool.
+func Put(buf []byte) {
+	builtinPool.Put(buf)
+}
+
+// Get retrieves a byte slice of the length requested by the caller from pool or allocates a new one.
+func (p *Pool) Get(size int) (buf []byte) {
+	if size <= 0 {
+		return nil
+	}
+	if size > math.MaxInt32 {
+		return make([]byte, size)
+	}
+	idx := index(uint32(size))
+	ptr, _ := p.pools[idx].Get().(unsafe.Pointer)
+	if ptr == nil {
+		return make([]byte, 1<<idx)[:size]
+	}
+	sh := (*reflect.SliceHeader)(unsafe.Pointer(&buf))
+	sh.Data = uintptr(ptr)
+	sh.Len = size
+	sh.Cap = 1 << idx
+	runtime.KeepAlive(ptr)
+	return
+}
+
+// Put returns the byte slice to the pool.
+func (p *Pool) Put(buf []byte) {
+	size := cap(buf)
+	if size == 0 || size > math.MaxInt32 {
+		return
+	}
+	idx := index(uint32(size))
+	if size != 1<<idx { // this byte slice is not from Pool.Get(), put it into the previous interval of idx
+		idx--
+	}
+	// array pointer
+	p.pools[idx].Put(unsafe.Pointer(&buf[:1][0]))
+}
+
+func index(n uint32) uint32 {
+	return uint32(bits.Len32(n - 1))
+}

--- a/redis/example_test.go
+++ b/redis/example_test.go
@@ -109,7 +109,7 @@ func ExampleSync() {
 	// Output:
 	// OK
 	// OK
-	// ["1" "2"]
+	// [{"1"} {"2"}]
 	// redispipe.result: WRONGTYPE Operation against a key holding the wrong kind of value {request: Req("HSET", ["key1" "field1" "val1"]), address: 127.0.0.1:46231}
 	// <nil>
 	// ['\x02' '\x01' "2" "1"]

--- a/redis/reader.go
+++ b/redis/reader.go
@@ -95,7 +95,7 @@ func ReadResponse(b *bufio.Reader) interface{} {
 			return ErrNoFinalRN.NewWithNoMessage()
 		}
 
-		return buf[:v]
+		return ByteResponse{Val: buf[:v]}
 	case '*':
 		var rerr *errorx.Error
 		if v, rerr = parseInt(line[1:]); rerr != nil {

--- a/redis/reader_test.go
+++ b/redis/reader_test.go
@@ -157,20 +157,20 @@ func TestReadResponse_Correct(t *testing.T) {
 
 	res = readLines("$0\r\n", "\r\n")
 	assert.Equal(t, []byte(""), res)
-	assert.Equal(t, len(res.([]byte)), cap(res.([]byte)))
+	assert.Equal(t, 0, len(res.([]byte)))
 
 	res = readLines("$1\r\n", "a\r\n")
 	assert.Equal(t, []byte("a"), res)
-	assert.Equal(t, len(res.([]byte)), cap(res.([]byte)))
+	assert.Equal(t, 1, len(res.([]byte)))
 
 	res = readLines("$4\r\n", "asdf\r\n")
 	assert.Equal(t, []byte("asdf"), res)
-	assert.Equal(t, len(res.([]byte)), cap(res.([]byte)))
+	assert.Equal(t, 4, len(res.([]byte)))
 
 	big := strings.Repeat("a", 1024*1024)
 	res = readLines(fmt.Sprintf("$%d\r\n", len(big)), big, "\r\n")
 	assert.Equal(t, []byte(big), res)
-	assert.Equal(t, len(res.([]byte)), cap(res.([]byte)))
+	assert.Equal(t, 1024*1024, len(res.([]byte)))
 
 	res = readLines("*0\r\n")
 	assert.Equal(t, []interface{}{}, res)

--- a/redis/reader_test.go
+++ b/redis/reader_test.go
@@ -156,21 +156,17 @@ func TestReadResponse_Correct(t *testing.T) {
 	assert.Equal(t, int64(-9223372036854775808), res)
 
 	res = readLines("$0\r\n", "\r\n")
-	assert.Equal(t, []byte(""), res)
-	assert.Equal(t, 0, len(res.([]byte)))
+	assert.Equal(t, ByteResponse{Val: []byte("")}, res)
 
 	res = readLines("$1\r\n", "a\r\n")
-	assert.Equal(t, []byte("a"), res)
-	assert.Equal(t, 1, len(res.([]byte)))
+	assert.Equal(t, ByteResponse{Val: []byte("a")}, res)
 
 	res = readLines("$4\r\n", "asdf\r\n")
-	assert.Equal(t, []byte("asdf"), res)
-	assert.Equal(t, 4, len(res.([]byte)))
+	assert.Equal(t, ByteResponse{Val: []byte("asdf")}, res)
 
 	big := strings.Repeat("a", 1024*1024)
 	res = readLines(fmt.Sprintf("$%d\r\n", len(big)), big, "\r\n")
-	assert.Equal(t, []byte(big), res)
-	assert.Equal(t, 1024*1024, len(res.([]byte)))
+	assert.Equal(t, ByteResponse{Val: []byte(big)}, res)
 
 	res = readLines("*0\r\n")
 	assert.Equal(t, []interface{}{}, res)

--- a/redis/reader_test.go
+++ b/redis/reader_test.go
@@ -18,7 +18,7 @@ func lines2bufio(lines ...string) *bufio.Reader {
 }
 
 func readLines(lines ...string) interface{} {
-	return ReadResponse(lines2bufio(lines...))
+	return ReadResponse(lines2bufio(lines...), true)
 }
 
 func checkErrType(t *testing.T, res interface{}, kind *errorx.Type) bool {

--- a/redis/request.go
+++ b/redis/request.go
@@ -4,15 +4,70 @@ import "fmt"
 
 // Req - convenient wrapper to create Request.
 func Req(cmd string, args ...interface{}) Request {
-	return Request{cmd, args}
+	return Request{cmd, nil, args, nil}
+}
+
+// ReqFromByteArgs creates a Request from a command, list of args in byte form, and
+// uses the provided buf to store the Request.EncodedBytes
+func ReqFromByteArgs(cmd string, args [][]byte, buf []byte) Request {
+	space := -1
+	for i, c := range cmd {
+		if c == ' ' {
+			space = i
+			break
+		}
+	}
+
+	if space == -1 {
+		buf = appendHead(buf, '*', len(args)+1)
+		buf = appendHead(buf, '$', len(cmd))
+		buf = append(buf, cmd...)
+		buf = append(buf, '\r', '\n')
+	} else {
+		buf = appendHead(buf, '*', len(args)+2)
+		buf = appendHead(buf, '$', space)
+		buf = append(buf, cmd[:space]...)
+		buf = append(buf, '\r', '\n')
+		buf = appendHead(buf, '$', len(cmd)-space-1)
+		buf = append(buf, cmd[space+1:]...)
+		buf = append(buf, '\r', '\n')
+	}
+
+	for _, arg := range args {
+		buf = appendHead(buf, '$', len(arg))
+		buf = append(buf, arg...)
+		buf = append(buf, '\r', '\n')
+	}
+
+	if cmd == "RANDOMKEY" {
+		return Request{Cmd: cmd, Args: nil, EncodedBytes: buf}
+	}
+
+	var n int
+	switch cmd {
+	case "FCALL", "FCALL_RO":
+		n = 2
+	case "EVAL", "EVALSHA":
+		n = 2
+	case "BITOP":
+		n = 1
+	default:
+		n = 0
+	}
+
+	return Request{Cmd: cmd, KeyBytes: args[n], Args: nil, EncodedBytes: buf}
 }
 
 // Request represents request to be passed to redis.
 type Request struct {
 	// Cmd is a redis command to be sent.
 	// It could contain single space, then it will be split, and last part will be serialized as an argument.
-	Cmd  string
-	Args []interface{}
+	Cmd      string
+	KeyBytes []byte
+
+	// Either specify Args to encode or pre-encoded request via EncodedBytes
+	Args         []interface{}
+	EncodedBytes []byte
 }
 
 func (r Request) String() string {
@@ -39,6 +94,11 @@ func (r Request) Key() (string, bool) {
 	if r.Cmd == "RANDOMKEY" {
 		return "RANDOMKEY", false
 	}
+
+	if r.KeyBytes != nil {
+		return string(r.KeyBytes), true
+	}
+
 	var n int
 	switch r.Cmd {
 	case "FCALL", "FCALL_RO":
@@ -63,6 +123,11 @@ func (r Request) KeyByte() ([]byte, bool) {
 	if r.Cmd == "RANDOMKEY" {
 		return rKey, false
 	}
+
+	if r.KeyBytes != nil {
+		return r.KeyBytes, true
+	}
+
 	var n int
 	switch r.Cmd {
 	case "FCALL", "FCALL_RO":

--- a/redis/request_writer.go
+++ b/redis/request_writer.go
@@ -13,6 +13,10 @@ import (
 //
 // Note: command could contain single space. In that case, it will be split and last part will be prepended to arguments.
 func AppendRequest(buf []byte, req Request) ([]byte, error) {
+	if len(req.EncodedBytes) != 0 {
+		return append(buf, req.EncodedBytes...), nil
+	}
+
 	oldSize := len(buf)
 	space := -1
 	for i, c := range []byte(req.Cmd) {

--- a/redis/sender.go
+++ b/redis/sender.go
@@ -79,7 +79,7 @@ func (s ScanOpts) Request(it []byte) Request {
 	if s.Count > 0 {
 		args = append(args, "COUNT", s.Count)
 	}
-	return Request{s.Cmd, args}
+	return Request{s.Cmd, nil, args, nil}
 }
 
 // ScannerBase is internal "parent" object for scanner implementations

--- a/redis/sync.go
+++ b/redis/sync.go
@@ -14,7 +14,7 @@ type Sync struct {
 // Do is convenient method to construct and send request.
 // Returns value that could be either result or error.
 func (s Sync) Do(cmd string, args ...interface{}) interface{} {
-	return s.Send(Request{cmd, args})
+	return s.Send(Request{cmd, nil, args, nil})
 }
 
 // Send sends request to redis.

--- a/redis/sync_context.go
+++ b/redis/sync_context.go
@@ -19,7 +19,7 @@ type SyncCtx struct {
 // Returns value that could be either result or error.
 // When context is cancelled, Do returns ErrRequestCancelled error.
 func (s SyncCtx) Do(ctx context.Context, cmd string, args ...interface{}) interface{} {
-	return s.Send(ctx, Request{cmd, args})
+	return s.Send(ctx, Request{cmd, nil, args, nil})
 }
 
 // Send sends request to redis.

--- a/rediscluster/bench/go.sum
+++ b/rediscluster/bench/go.sum
@@ -1,12 +1,16 @@
+github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
+github.com/cockroachdb/circuitbreaker v0.0.0-20210826084326-2045d59d3b5d/go.mod h1:mN5a3LcljXtJdPkmDnkbSCjPEmImXBXR+jmS31mxVwA=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a/go.mod h1:7Ga40egUymuWXxAe151lTNnCv97MddSOVsjpPPkityA=
 github.com/garyburd/redigo v1.6.2/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
 github.com/joomcode/errorx v1.0.3 h1:3e1mi0u7/HTPNdg6d6DYyKGBhA5l9XpsfuVE29NxnWw=
 github.com/joomcode/errorx v1.0.3/go.mod h1:eQzdtdlNyN7etw6YCS4W4+lu442waxZYw5yvz0ULrRo=
 github.com/mediocregopher/radix.v2 v0.0.0-20181115013041-b67df6e626f9/go.mod h1:fLRUbhbSd5Px2yKUaGYYPltlyxi1guJz1vCmo1RQL50=
 github.com/mediocregopher/radix/v3 v3.7.0 h1:SM9zJdme5pYGEVvh1HttjBjDmIaNBDKy+oDCv5w81Wo=
 github.com/mediocregopher/radix/v3 v3.7.0/go.mod h1:8FL3F6UQRXHXIBSPUs5h0RybMF8i4n7wVopoX3x7Bv8=
+github.com/peterbourgon/g2s v0.0.0-20170223122336-d4e7ad98afea/go.mod h1:1VcHEd3ro4QMoHfiNl/j7Jkln9+KQuorp0PItHMJYNg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/rediscluster/cluster_test.go
+++ b/rediscluster/cluster_test.go
@@ -145,7 +145,7 @@ func (s *Suite) TestBasicOps() {
 		s.slotnode(i).DoSure("SET", slotkey("basic", key), key+"y")
 	}
 	for _, key := range s.keys {
-		s.Equal([]byte(key+"y"), scl.Do(s.ctx, "GET", slotkey("basic", key)))
+		s.Equal(redis.ByteResponse{Val: []byte(key + "y")}, scl.Do(s.ctx, "GET", slotkey("basic", key)))
 	}
 }
 
@@ -256,7 +256,7 @@ func (s *Suite) TestSendMany() {
 	}
 	ress = scl.SendMany(s.ctx, reqs)
 	for i, res := range ress {
-		s.Equal([]byte(s.keys[i]+"y"), res)
+		s.Equal(redis.ByteResponse{Val: []byte(s.keys[i] + "y")}, res)
 	}
 }
 

--- a/rediscluster/slotrange.go
+++ b/rediscluster/slotrange.go
@@ -246,9 +246,9 @@ func (cfg *clusterConfig) setConnRoles() {
 			}
 			for _, conn := range node.conns {
 				if i == 0 {
-					conn.Send(Request{"READWRITE", nil}, nil, 0)
+					conn.Send(Request{"READWRITE", nil, nil, nil}, nil, 0)
 				} else {
-					conn.SendBatch([]Request{{"READONLY", nil}, {"INFO", nil}},
+					conn.SendBatch([]Request{{"READONLY", nil, nil, nil}, {"INFO", nil, nil, nil}},
 						redis.FuncFuture(sh.setReplicaInfo), uint64(i*2))
 				}
 			}

--- a/redisconn/bench/go.sum
+++ b/redisconn/bench/go.sum
@@ -1,6 +1,9 @@
+github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
+github.com/cockroachdb/circuitbreaker v0.0.0-20210826084326-2045d59d3b5d/go.mod h1:mN5a3LcljXtJdPkmDnkbSCjPEmImXBXR+jmS31mxVwA=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a/go.mod h1:7Ga40egUymuWXxAe151lTNnCv97MddSOVsjpPPkityA=
 github.com/garyburd/redigo v1.6.2/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
 github.com/gomodule/redigo v1.8.4 h1:Z5JUg94HMTR1XpwBaSH4vq3+PNSIykBLxMdglbw10gg=
 github.com/gomodule/redigo v1.8.4/go.mod h1:P9dn9mFrCBvWhGE1wpxx6fgq7BAeLBk+UUUzlpkBYO0=
@@ -9,6 +12,7 @@ github.com/joomcode/errorx v1.0.3/go.mod h1:eQzdtdlNyN7etw6YCS4W4+lu442waxZYw5yv
 github.com/mediocregopher/radix.v2 v0.0.0-20181115013041-b67df6e626f9/go.mod h1:fLRUbhbSd5Px2yKUaGYYPltlyxi1guJz1vCmo1RQL50=
 github.com/mediocregopher/radix/v3 v3.7.0 h1:SM9zJdme5pYGEVvh1HttjBjDmIaNBDKy+oDCv5w81Wo=
 github.com/mediocregopher/radix/v3 v3.7.0/go.mod h1:8FL3F6UQRXHXIBSPUs5h0RybMF8i4n7wVopoX3x7Bv8=
+github.com/peterbourgon/g2s v0.0.0-20170223122336-d4e7ad98afea/go.mod h1:1VcHEd3ro4QMoHfiNl/j7Jkln9+KQuorp0PItHMJYNg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/redisconn/conn.go
+++ b/redisconn/conn.go
@@ -616,7 +616,7 @@ func (conn *Connection) dial() error {
 	var res interface{}
 	// Password response
 	if conn.opts.Password != "" {
-		res = redis.ReadResponse(r)
+		res = redis.ReadResponse(r, false)
 		if err := redis.AsErrorx(res); err != nil {
 			connection.Close()
 			if !err.IsOfType(redis.ErrIO) {
@@ -626,7 +626,7 @@ func (conn *Connection) dial() error {
 		}
 	}
 	// PING Response
-	res = redis.ReadResponse(r)
+	res = redis.ReadResponse(r, false)
 	if err := redis.AsErrorx(res); err != nil {
 		connection.Close()
 		if !err.IsOfType(redis.ErrIO) {
@@ -642,7 +642,7 @@ func (conn *Connection) dial() error {
 	}
 	// SELECT DB Response
 	if conn.opts.DB != 0 {
-		res = redis.ReadResponse(r)
+		res = redis.ReadResponse(r, false)
 		if err := redis.AsErrorx(res); err != nil {
 			connection.Close()
 			if !err.IsOfType(redis.ErrIO) {
@@ -940,7 +940,7 @@ func (conn *Connection) reader(r *bufio.Reader, one *oneconn) {
 	for {
 		// try to read response from buffered socket.
 		// Here is IOTimeout handled as well (through deadlineIO wrapper around socket).
-		res = redis.ReadResponse(r)
+		res = redis.ReadResponse(r, true)
 		if rerr := redis.AsErrorx(res); rerr != nil {
 			if !rerr.IsOfType(redis.ErrResult) {
 				// it is not redis-sended error, then close connection

--- a/redisconn/conn.go
+++ b/redisconn/conn.go
@@ -380,7 +380,7 @@ func (conn *Connection) doSend(req Request, cb Future, n uint64, asking bool) *e
 	futures := conn.futures
 	if asking {
 		// send ASKING request before actual
-		futures = append(futures, future{&dumb, 0, 0, Request{"ASKING", nil}})
+		futures = append(futures, future{&dumb, 0, 0, Request{"ASKING", nil, nil, nil}})
 	}
 	futures = append(futures, future{cb, n, nownano(), req})
 
@@ -492,11 +492,11 @@ func (conn *Connection) doSendBatch(requests []Request, cb Future, start uint64,
 	futures := conn.futures
 	if flags&DoAsking != 0 {
 		// send ASKING request before actual
-		futures = append(futures, future{&dumb, 0, 0, Request{"ASKING", nil}})
+		futures = append(futures, future{&dumb, 0, 0, Request{"ASKING", nil, nil, nil}})
 	}
 	if flags&DoTransaction != 0 {
 		// send MULTI request for transaction start
-		futures = append(futures, future{&dumb, 0, 0, Request{"MULTI", nil}})
+		futures = append(futures, future{&dumb, 0, 0, Request{"MULTI", nil, nil, nil}})
 	}
 
 	now := nownano()
@@ -507,7 +507,7 @@ func (conn *Connection) doSendBatch(requests []Request, cb Future, start uint64,
 
 	if flags&DoTransaction != 0 {
 		// send EXEC request for transaction end
-		futures = append(futures, future{cb, start + uint64(len(requests)), now, Request{"EXEC", nil}})
+		futures = append(futures, future{cb, start + uint64(len(requests)), now, Request{"EXEC", nil, nil, nil}})
 	}
 
 	// should notify writer about this shard having queries

--- a/redisconn/conn_test.go
+++ b/redisconn/conn_test.go
@@ -121,7 +121,7 @@ func (s *Suite) TestConnectsDb() {
 	res := sync1.Do("SET", "db", 0)
 	s.r().NoError(redis.AsError(res))
 	res = sync1.Do("GET", "db")
-	s.r().Equal(res, []byte("0"))
+	s.r().Equal(redis.ByteResponse{Val: []byte("0")}, res)
 
 	opts2 := defopts
 	opts2.DB = 1
@@ -134,10 +134,9 @@ func (s *Suite) TestConnectsDb() {
 	res = sync2.Do("SET", "db", 1)
 	s.r().NoError(redis.AsError(res))
 	res = sync2.Do("GET", "db")
-	s.r().Equal(res, []byte("1"))
-
+	s.r().Equal(redis.ByteResponse{Val: []byte("1")}, res)
 	res = sync1.Do("GET", "db")
-	s.r().Equal(res, []byte("0"))
+	s.r().Equal(redis.ByteResponse{Val: []byte("0")}, res)
 }
 
 func (s *Suite) TestFailedWithWrongDB() {
@@ -398,17 +397,17 @@ func (s *Suite) TestAllReturns_Good() {
 			for j := 0; j < K; j++ {
 				sij := strconv.Itoa(i*N + j)
 				res := sconn.Do(s.ctx, "PING", sij)
-				if !s.IsType([]byte{}, res) || !s.Equal(sij, string(res.([]byte))) {
+				if !s.IsType(redis.ByteResponse{}, res) || !s.Equal(sij, string(res.(redis.ByteResponse).Val)) {
 					return
 				}
 				ress := sconn.SendMany(s.ctx, []redis.Request{
 					redis.Req("PING", "a"+sij),
 					redis.Req("PING", "b"+sij),
 				})
-				if !s.IsType([]byte{}, ress[0]) || !s.Equal("a"+sij, string(ress[0].([]byte))) {
+				if !s.IsType(redis.ByteResponse{}, ress[0]) || !s.Equal("a"+sij, string(ress[0].(redis.ByteResponse).Val)) {
 					return
 				}
-				if !s.IsType([]byte{}, ress[1]) || !s.Equal("b"+sij, string(ress[1].([]byte))) {
+				if !s.IsType(redis.ByteResponse{}, ress[1]) || !s.Equal("b"+sij, string(ress[1].(redis.ByteResponse).Val)) {
 					return
 				}
 			}
@@ -465,9 +464,9 @@ func (s *Suite) TestAllReturns_Bad() {
 					redis.Req("PING", "b"+sij),
 				})
 				if check && good {
-					ok := s.IsType([]byte{}, res) && s.Equal(sij, string(res.([]byte)))
-					ok = ok && s.IsType([]byte{}, ress[0]) && s.Equal("a"+sij, string(ress[0].([]byte)))
-					ok = ok && s.IsType([]byte{}, ress[1]) && s.Equal("b"+sij, string(ress[1].([]byte)))
+					ok := s.IsType(redis.ByteResponse{}, res) && s.Equal(sij, string(res.(redis.ByteResponse).Val))
+					ok = ok && s.IsType(redis.ByteResponse{}, ress[0]) && s.Equal("a"+sij, string(ress[0].(redis.ByteResponse).Val))
+					ok = ok && s.IsType(redis.ByteResponse{}, ress[1]) && s.Equal("b"+sij, string(ress[1].(redis.ByteResponse).Val))
 					checks <- ok
 				} else if check && !good {
 					ok := s.IsType((*errorx.Error)(nil), res)

--- a/redisdumb/conn.go
+++ b/redisdumb/conn.go
@@ -62,9 +62,13 @@ func (c *Conn) Do(cmd string, args ...interface{}) interface{} {
 		req, err = redis.AppendRequest(nil, redis.Request{cmd, nil, args, nil})
 		if err == nil {
 			if _, err = c.C.Write(req); err == nil {
-				res := redis.ReadResponse(c.R)
+				res := redis.ReadResponse(c.R, true)
 				rerr := redis.AsErrorx(res)
 				if rerr == nil {
+					if br, ok := res.(redis.ByteResponse); ok {
+						return br.Val
+					}
+
 					return res
 				}
 				err = rerr
@@ -201,6 +205,6 @@ func Do(addr string, cmd string, args ...interface{}) interface{} {
 	if _, err = conn.Write(req); err != nil {
 		return redis.ErrIO.WrapWithNoMessage(err)
 	}
-	res := redis.ReadResponse(bufio.NewReader(conn))
+	res := redis.ReadResponse(bufio.NewReader(conn), false)
 	return res
 }

--- a/redisdumb/conn.go
+++ b/redisdumb/conn.go
@@ -59,7 +59,7 @@ func (c *Conn) Do(cmd string, args ...interface{}) interface{} {
 			c.Do("ASKING")
 		}
 		c.C.SetDeadline(time.Now().Add(timeout))
-		req, err = redis.AppendRequest(nil, redis.Request{cmd, args})
+		req, err = redis.AppendRequest(nil, redis.Request{cmd, nil, args, nil})
 		if err == nil {
 			if _, err = c.C.Write(req); err == nil {
 				res := redis.ReadResponse(c.R)
@@ -194,7 +194,7 @@ func Do(addr string, cmd string, args ...interface{}) interface{} {
 	}
 	defer conn.Close()
 	conn.SetDeadline(time.Now().Add(DefaultTimeout))
-	req, rerr := redis.AppendRequest(nil, redis.Request{cmd, args})
+	req, rerr := redis.AppendRequest(nil, redis.Request{cmd, nil, args, nil})
 	if rerr != nil {
 		return rerr
 	}


### PR DESCRIPTION
This change introduces a new return type for RESP bulk string responses. Instead of returning `[]byte` we return a `BytesResponse` which stores `[]byte`. The receiver should then call `BytesResponse.Release()` when they are done reading the response in order to put `[]byte` back into the pool for later re-use.

Edit: note on test failures here, there's a flaky test (false negative) that's happening which is unrelated to these changes.