### PR TITLE
ensure replicas are fully up

### DIFF
--- a/testbed/cluster.go
+++ b/testbed/cluster.go
@@ -2,7 +2,6 @@ package testbed
 
 import (
 	"bytes"
-	"fmt"
 	"log"
 	"time"
 
@@ -85,7 +84,6 @@ func (cl *Cluster) WaitClusterOk() {
 	for !cl.ClusterOk() {
 		if i++; i == 15 {
 			cl.AttemptFailover()
-			fmt.Println("did failover")
 		}
 		time.Sleep(1000 * time.Millisecond)
 	}
@@ -177,7 +175,6 @@ func (cl *Cluster) ClusterOk() bool {
 	}
 
 	if assignedNodes < 6 && assignedNodes != len(cl.Node)-len(stopped) {
-		fmt.Println("running nodes ver live nodes error", len(cl.Node)-len(stopped), assignedNodes)
 		return false
 	}
 


### PR DESCRIPTION
I found that the `ClusterOk` checks are not sufficient for newer versions of clustered redis. The only consistent way that I've found to ensure that all replicas have loaded a snapshot from their primary and are ready to serve is via checking the output of `cluster slots` and verifying they are serving slots. Simply looking at `info replication` data was not sufficient.

The only reason this has worked up to now is the test order does not require replicas to fully be up until later. This had the confusing effect of causing some tests to fail when run individually.